### PR TITLE
Update product_category table entries to reference to their child in addition to their parent

### DIFF
--- a/database/mysql/create_tables.sql
+++ b/database/mysql/create_tables.sql
@@ -45,8 +45,10 @@ CREATE TABLE IF NOT EXISTS product_category
 (
     category_name VARCHAR(45),
     parent        VARCHAR(45) DEFAULT NULL,
+    child         VARCHAR(45) DEFAULT NULL,
     CONSTRAINT product_category_pk PRIMARY KEY (category_name),
-    CONSTRAINT product_category_parent_fk FOREIGN KEY (parent) REFERENCES product_category (category_name)
+    CONSTRAINT product_category_parent_fk FOREIGN KEY (parent) REFERENCES product_category (category_name),
+    CONSTRAINT product_category_child_fk FOREIGN KEY (child) REFERENCES product_category (child)
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS product_attribute

--- a/database/mysql/create_tables.sql
+++ b/database/mysql/create_tables.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS product_category
     child         VARCHAR(45) DEFAULT NULL,
     CONSTRAINT product_category_pk PRIMARY KEY (category_name),
     CONSTRAINT product_category_parent_fk FOREIGN KEY (parent) REFERENCES product_category (category_name),
-    CONSTRAINT product_category_child_fk FOREIGN KEY (child) REFERENCES product_category (child)
+    CONSTRAINT product_category_child_fk FOREIGN KEY (child) REFERENCES product_category (category_name)
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS product_attribute


### PR DESCRIPTION
### Old table:

```mysql
CREATE TABLE IF NOT EXISTS product_category
(
    category_name VARCHAR(45),
    parent        VARCHAR(45) DEFAULT NULL,
    CONSTRAINT product_category_pk PRIMARY KEY (category_name),
    CONSTRAINT product_category_parent_fk FOREIGN KEY (parent) REFERENCES product_category (category_name)
) ENGINE = InnoDB;
```

### New table:

```mysql
CREATE TABLE IF NOT EXISTS product_category
(
    category_name VARCHAR(45),
    parent        VARCHAR(45) DEFAULT NULL,
    child         VARCHAR(45) DEFAULT NULL,
    CONSTRAINT product_category_pk PRIMARY KEY (category_name),
    CONSTRAINT product_category_parent_fk FOREIGN KEY (parent) REFERENCES product_category (category_name),
    CONSTRAINT product_category_child_fk FOREIGN KEY (child) REFERENCES product_category (category_name)
) ENGINE = InnoDB;
```

### Changes:

One new column with foreign key constraint: `product_category.child`