### PR TITLE
Bugfix: Move product error

### DIFF
--- a/database/mysql/init/business_rules.sql
+++ b/database/mysql/init/business_rules.sql
@@ -47,7 +47,8 @@ BEGIN
     IF move_quantity > @from_warehouse_product_quantity THEN SET result = 1; ROLLBACK; LEAVE this_proc; END IF;
 
     -- Calculate available space in to_warehouse
-    SELECT w.volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)
+    SELECT volume INTO @to_warehouse_total_volume FROM warehouse WHERE id = to_warehouse FOR SHARE;
+    SELECT @to_warehouse_total_volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)
     INTO @to_warehouse_available_volume
     FROM stockpile s
         LEFT JOIN warehouse w ON s.warehouse_id = w.id

--- a/database/mysql/init/business_rules.sql
+++ b/database/mysql/init/business_rules.sql
@@ -2,7 +2,7 @@ USE isys2099_group9_app;
 
 
 /*
- sp_move_product(product_id: int, move_quantity: int, from_warehouse: int, to_warehouse: int, OUT result: int)
+ sp_move_product(move_product: int, move_quantity: int, from_warehouse: int, to_warehouse: int, OUT result: int)
 
  OUT result:
     -1 on rollback


### PR DESCRIPTION
Resolve #69 
---

The problem lies here, in the `database/mysql/init/business_rules.sql` file starting from line 49:

```sql
-- Calculate available space in to_warehouse
SELECT w.volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)
INTO @to_warehouse_available_volume
FROM stockpile s
    LEFT JOIN warehouse w ON s.warehouse_id = w.id
    LEFT JOIN product p on s.product_id = p.id
WHERE w.id = to_warehouse FOR SHARE;
```

This runs fine in MySQL 8.0.28 and 8.0.29, because `w.volume` only returns 1 row, thus `w.volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)` evaluates to 1 row, and can fit into `@to_warehouse_available_volume`.

However, on version 8.0.33, `w.volume` returns multiple rows, thus `w.volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)` also evaluates to multiple rows, which cannot fit into `@to_warehouse_available_volume`, raising a `SQLEXCEPTION` and trigger a `ROLLBACK`, thus setting the `OUT result` paramater to -1.

This is my workaround:

```sql
-- Calculate available space in to_warehouse
SELECT volume INTO @to_warehouse_total_volume FROM warehouse WHERE id = to_warehouse FOR SHARE;
SELECT @to_warehouse_total_volume - coalesce(sum(s.quantity * p.width * p.length * p.height), 0)
INTO @to_warehouse_available_volume
FROM stockpile s
    LEFT JOIN warehouse w ON s.warehouse_id = w.id
    LEFT JOIN product p on s.product_id = p.id
WHERE w.id = to_warehouse FOR SHARE;
```

The statement `SELECT volume INTO @to_warehouse_total_volume FROM warehouse WHERE id = to_warehouse FOR SHARE;` guarantees that the `warehouse.volume` we get is always a single row. Ths